### PR TITLE
Improved algorithm for combining metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 ![Python package](https://github.com/biomarkersparkinson/tsdf/workflows/Python%20package/badge.svg)
+[![PyPI](https://img.shields.io/pypi/v/tsdf.svg)](https://pypi.python.org/pypi/tsdf/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7867900.svg)](https://doi.org/10.5281/zenodo.7867900)
 
 # tsdf

--- a/docs/processing_example.ipynb
+++ b/docs/processing_example.ipynb
@@ -12,9 +12,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "# Reload modules automatically on changes; useful for developing\n",
     "%load_ext autoreload\n",
@@ -31,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -56,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,9 +201,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
+      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
+      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
+      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
+      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
+      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
+      "[0.00469378, 0.00469378, 0.00469378]\n",
+      "[0.00469378, 0.00469378, 0.00469378]\n",
+      "[0.00469378, 0.00469378, 0.00469378]\n"
+     ]
+    },
+    {
+     "ename": "KeyError",
+     "evalue": "'scale_factors'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[18], line 19\u001b[0m\n\u001b[1;32m     11\u001b[0m processed_dummy_metadata_2 \u001b[39m=\u001b[39m tsdf\u001b[39m.\u001b[39mwrite_binary_file(\n\u001b[1;32m     12\u001b[0m             TESTDATA_DIR,\n\u001b[1;32m     13\u001b[0m             processed_dummy_data_name_2 \u001b[39m+\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m.bin\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[1;32m     14\u001b[0m             processed_dummy_data_2,\n\u001b[1;32m     15\u001b[0m             updated_dummy_metadata,\n\u001b[1;32m     16\u001b[0m         )\n\u001b[1;32m     18\u001b[0m \u001b[39m# Write a metadata file that combines the two binary files\u001b[39;00m\n\u001b[0;32m---> 19\u001b[0m tsdf\u001b[39m.\u001b[39;49mwrite_metadata([processed_dummy_metadata_1, processed_dummy_metadata_2], \u001b[39m\"\u001b[39;49m\u001b[39mtmp_test_dummy_10_3_int16_to_int_n_float.json\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
+      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:148\u001b[0m, in \u001b[0;36mwrite_metadata\u001b[0;34m(metadatas, file_name)\u001b[0m\n\u001b[1;32m    143\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m overlap:\n\u001b[1;32m    144\u001b[0m     \u001b[39mraise\u001b[39;00m TSDFMetadataFieldValueError(\n\u001b[1;32m    145\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mMetadata files mist have at least one common field. Otherwise, they should be stored separately.\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    146\u001b[0m     )\n\u001b[0;32m--> 148\u001b[0m overlap[\u001b[39m\"\u001b[39m\u001b[39msensors\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m calculate_ovelaps_rec(plain_meta)\n\u001b[1;32m    149\u001b[0m write_to_file(overlap, metadatas[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mfile_dir_path, file_name)\n",
+      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:180\u001b[0m, in \u001b[0;36mcalculate_ovelaps_rec\u001b[0;34m(metadatas)\u001b[0m\n\u001b[1;32m    177\u001b[0m final_metadata: List[Dict[\u001b[39mstr\u001b[39m, Any]] \u001b[39m=\u001b[39m [] \u001b[39m# The metadata that is left to be processed\u001b[39;00m\n\u001b[1;32m    179\u001b[0m \u001b[39mfor\u001b[39;00m key \u001b[39min\u001b[39;00m get_all_keys(metadatas):\n\u001b[0;32m--> 180\u001b[0m     overlap_per_key[key] \u001b[39m=\u001b[39m calculate_max_overlap(metadatas, key)\n\u001b[1;32m    182\u001b[0m max_key \u001b[39m=\u001b[39m max_len_key(overlap_per_key)\n\u001b[1;32m    184\u001b[0m first_group \u001b[39m=\u001b[39m overlap_per_key[max_key]\n",
+      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:218\u001b[0m, in \u001b[0;36mcalculate_max_overlap\u001b[0;34m(meta_files, meta_key)\u001b[0m\n\u001b[1;32m    216\u001b[0m values : Dict[\u001b[39mstr\u001b[39m, List[Dict[\u001b[39mstr\u001b[39m, Any]]] \u001b[39m=\u001b[39m {} \u001b[39m# Key: a value for the given meta_key, Value: list of metadata files that have that value\u001b[39;00m\n\u001b[1;32m    217\u001b[0m \u001b[39mfor\u001b[39;00m meta \u001b[39min\u001b[39;00m meta_files:\n\u001b[0;32m--> 218\u001b[0m     \u001b[39mprint\u001b[39m(meta[meta_key])\n\u001b[1;32m    219\u001b[0m     curr_value \u001b[39m=\u001b[39m meta[meta_key]\n\u001b[1;32m    220\u001b[0m     \u001b[39mprint\u001b[39m(curr_value)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'scale_factors'"
+     ]
+    }
+   ],
    "source": [
     "# Preprocess the original data to generate another data source\n",
     "processed_dummy_data_2 = (dummy_data * 1000).astype('int32')\n",
@@ -228,9 +267,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'os' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m path \u001b[39m=\u001b[39m os\u001b[39m.\u001b[39mpath\u001b[39m.\u001b[39mjoin(TESTDATA_DIR, \u001b[39m\"\u001b[39m\u001b[39mtest_output_1.bin\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m rs \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39mrandom\u001b[39m.\u001b[39mRandomState(seed\u001b[39m=\u001b[39m\u001b[39m42\u001b[39m)\n\u001b[1;32m      3\u001b[0m data_1 \u001b[39m=\u001b[39m rs\u001b[39m.\u001b[39mrand(\u001b[39m17\u001b[39m, \u001b[39m1\u001b[39m)\u001b[39m.\u001b[39mastype(np\u001b[39m.\u001b[39mfloat32)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'os' is not defined"
+     ]
+    }
+   ],
    "source": [
     "path = os.path.join(TESTDATA_DIR, \"test_output_1.bin\")\n",
     "rs = np.random.RandomState(seed=42)\n",
@@ -269,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_example.ipynb
+++ b/docs/processing_example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 47,
    "metadata": {
     "tags": []
    },
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,39 +201,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
-      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
-      "tmp_test_dummy_10_3_int16_to_float32.bin\n",
-      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
-      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
-      "tmp_test_dummy_10_3_int16_to_int32.bin\n",
-      "[0.00469378, 0.00469378, 0.00469378]\n",
-      "[0.00469378, 0.00469378, 0.00469378]\n",
-      "[0.00469378, 0.00469378, 0.00469378]\n"
-     ]
-    },
-    {
-     "ename": "KeyError",
-     "evalue": "'scale_factors'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[18], line 19\u001b[0m\n\u001b[1;32m     11\u001b[0m processed_dummy_metadata_2 \u001b[39m=\u001b[39m tsdf\u001b[39m.\u001b[39mwrite_binary_file(\n\u001b[1;32m     12\u001b[0m             TESTDATA_DIR,\n\u001b[1;32m     13\u001b[0m             processed_dummy_data_name_2 \u001b[39m+\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m.bin\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[1;32m     14\u001b[0m             processed_dummy_data_2,\n\u001b[1;32m     15\u001b[0m             updated_dummy_metadata,\n\u001b[1;32m     16\u001b[0m         )\n\u001b[1;32m     18\u001b[0m \u001b[39m# Write a metadata file that combines the two binary files\u001b[39;00m\n\u001b[0;32m---> 19\u001b[0m tsdf\u001b[39m.\u001b[39;49mwrite_metadata([processed_dummy_metadata_1, processed_dummy_metadata_2], \u001b[39m\"\u001b[39;49m\u001b[39mtmp_test_dummy_10_3_int16_to_int_n_float.json\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
-      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:148\u001b[0m, in \u001b[0;36mwrite_metadata\u001b[0;34m(metadatas, file_name)\u001b[0m\n\u001b[1;32m    143\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m overlap:\n\u001b[1;32m    144\u001b[0m     \u001b[39mraise\u001b[39;00m TSDFMetadataFieldValueError(\n\u001b[1;32m    145\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mMetadata files mist have at least one common field. Otherwise, they should be stored separately.\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    146\u001b[0m     )\n\u001b[0;32m--> 148\u001b[0m overlap[\u001b[39m\"\u001b[39m\u001b[39msensors\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m calculate_ovelaps_rec(plain_meta)\n\u001b[1;32m    149\u001b[0m write_to_file(overlap, metadatas[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mfile_dir_path, file_name)\n",
-      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:180\u001b[0m, in \u001b[0;36mcalculate_ovelaps_rec\u001b[0;34m(metadatas)\u001b[0m\n\u001b[1;32m    177\u001b[0m final_metadata: List[Dict[\u001b[39mstr\u001b[39m, Any]] \u001b[39m=\u001b[39m [] \u001b[39m# The metadata that is left to be processed\u001b[39;00m\n\u001b[1;32m    179\u001b[0m \u001b[39mfor\u001b[39;00m key \u001b[39min\u001b[39;00m get_all_keys(metadatas):\n\u001b[0;32m--> 180\u001b[0m     overlap_per_key[key] \u001b[39m=\u001b[39m calculate_max_overlap(metadatas, key)\n\u001b[1;32m    182\u001b[0m max_key \u001b[39m=\u001b[39m max_len_key(overlap_per_key)\n\u001b[1;32m    184\u001b[0m first_group \u001b[39m=\u001b[39m overlap_per_key[max_key]\n",
-      "File \u001b[0;32m~/git/biomarkers_repo/tsdf/src/tsdf/io.py:218\u001b[0m, in \u001b[0;36mcalculate_max_overlap\u001b[0;34m(meta_files, meta_key)\u001b[0m\n\u001b[1;32m    216\u001b[0m values : Dict[\u001b[39mstr\u001b[39m, List[Dict[\u001b[39mstr\u001b[39m, Any]]] \u001b[39m=\u001b[39m {} \u001b[39m# Key: a value for the given meta_key, Value: list of metadata files that have that value\u001b[39;00m\n\u001b[1;32m    217\u001b[0m \u001b[39mfor\u001b[39;00m meta \u001b[39min\u001b[39;00m meta_files:\n\u001b[0;32m--> 218\u001b[0m     \u001b[39mprint\u001b[39m(meta[meta_key])\n\u001b[1;32m    219\u001b[0m     curr_value \u001b[39m=\u001b[39m meta[meta_key]\n\u001b[1;32m    220\u001b[0m     \u001b[39mprint\u001b[39m(curr_value)\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'scale_factors'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Preprocess the original data to generate another data source\n",
     "processed_dummy_data_2 = (dummy_data * 1000).astype('int32')\n",
@@ -267,26 +237,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'os' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m path \u001b[39m=\u001b[39m os\u001b[39m.\u001b[39mpath\u001b[39m.\u001b[39mjoin(TESTDATA_DIR, \u001b[39m\"\u001b[39m\u001b[39mtest_output_1.bin\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m rs \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39mrandom\u001b[39m.\u001b[39mRandomState(seed\u001b[39m=\u001b[39m\u001b[39m42\u001b[39m)\n\u001b[1;32m      3\u001b[0m data_1 \u001b[39m=\u001b[39m rs\u001b[39m.\u001b[39mrand(\u001b[39m17\u001b[39m, \u001b[39m1\u001b[39m)\u001b[39m.\u001b[39mastype(np\u001b[39m.\u001b[39mfloat32)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'os' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "path = os.path.join(TESTDATA_DIR, \"test_output_1.bin\")\n",
     "rs = np.random.RandomState(seed=42)\n",
     "data_1 = rs.rand(17, 1).astype(np.float32)\n",
     "data_2 = rs.rand(15, 2).astype(np.int16)\n",
+    "data_3 = rs.rand(10, 3).astype(np.int16)\n",
     "\n",
     "\n",
     "# An example where the metadata is defined from scratch\n",
@@ -303,11 +262,12 @@
     "new_metadata[\"channels\"] = [\"x\",\"y\",\"z\"]\n",
     "new_metadata[\"units\"] = [\"m/s/s\",\"m/s/s\",\"m/s/s\"]\n",
     "\n",
-    "# Write the two binary files based on the provided metadata\n",
+    "# Write the three binary files based on the provided metadata\n",
     "\n",
     "file_prefix = \"tmp_test\"\n",
     "new_meta_1 =  tsdf.write_binary_file(TESTDATA_DIR, file_prefix + \"_1.bin\", data_1, new_metadata)\n",
-    "new_meta_2 =  tsdf.write_binary_file(TESTDATA_DIR, file_prefix+\"_2.bin\", data_2, new_metadata)\n"
+    "new_meta_2 =  tsdf.write_binary_file(TESTDATA_DIR, file_prefix+\"_2.bin\", data_2, new_metadata)\n",
+    "new_meta_3 =  tsdf.write_binary_file(TESTDATA_DIR, file_prefix+\"_3.bin\", data_3, new_metadata)\n"
    ]
   },
   {
@@ -320,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,12 +290,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Combine and write both metadata files\n",
-    "tsdf.write_metadata([new_meta_1, new_meta_2], file_prefix+\"_2.json\")"
+    "tsdf.write_metadata([new_meta_1, new_meta_2, new_meta_3], file_prefix+\"_3.json\")"
    ]
   }
  ],

--- a/docs/processing_example.ipynb
+++ b/docs/processing_example.ipynb
@@ -11,8 +11,43 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to run these examples\n",
+    "\n",
+    "### Dependencies\n",
+    "\n",
+    "In order to run these examples, we'll need to use the following Python packages:\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tsdf\n",
+    "import os\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test  files\n",
+    "\n",
+    "The test files used in these examples can be found in [`./tests/data/`](https://github.com/biomarkersParkinson/tsdf/tree/main/tests/data). Use the snippet below to locate your copy of the files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,20 +65,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import tsdf\n",
-    "import os\n",
-    "import sys\n",
-    "import numpy as np"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -56,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/processing_example.ipynb
+++ b/docs/processing_example.ipynb
@@ -12,18 +12,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 72,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Reload modules automatically on changes; useful for developing\n",
     "%load_ext autoreload\n",
@@ -40,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 73,
    "metadata": {
     "tags": []
    },
@@ -65,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -130,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,11 +281,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Combine and write both metadata files\n",
+    "# Combine and write all metadata files\n",
     "tsdf.write_metadata([new_meta_1, new_meta_2, new_meta_3], file_prefix+\"_3.json\")"
    ]
   }

--- a/src/tsdf/io.py
+++ b/src/tsdf/io.py
@@ -181,11 +181,19 @@ def calculate_ovelaps_rec(
 
     max_key = max_len_key(overlap_per_key)
 
-    final_metadata.append(group_by_key(metadatas, max_key))
+    first_group = overlap_per_key[max_key]
+    second_grop = [meta for meta in metadatas if meta not in first_group]
 
-    # final_metadata.append(calculate_ovelaps_rec()
+    # Handle the first group
+    first_overlap = extract_common_fields(first_group)
+    first_overlap["sensors"] = calculate_ovelaps_rec(first_group)
+    final_metadata.append(first_overlap)
 
-# ...
+    # Handle the rest of the elements
+    second_overlap = calculate_ovelaps_rec(second_grop)
+    final_metadata.extend(second_overlap)
+    
+
     return final_metadata
 
 
@@ -203,14 +211,15 @@ def write_to_file(dict: Dict[str, Any], dir_path: str, file_name: str) -> None:
         convert_file.write(json.dumps(dict))
 
 
-def calculate_max_overlap(meta_files: List[Dict[str, Any]], max_key: str) -> List[Dict[str, Any]]:
-    """Calculate the maximum overlap between the metadata files, for a specific key and return the results as a dictionary."""
-    values : Dict[str, List[Dict[str, Any]]] = {}
+def calculate_max_overlap(meta_files: List[Dict[str, Any]], meta_key: str) -> List[Dict[str, Any]]:
+    """Calculate the maximum overlap between the metadata files, for a specific key. It returns the biggest group of dictionaries that contain the same value for the given meta_key."""
+    values : Dict[str, List[Dict[str, Any]]] = {} # Key: a value for the given meta_key, Value: list of metadata files that have that value
     for meta in meta_files:
-        curr = meta[max_key]
-        if curr not in values.keys():
-            values[curr] = [meta]
-        values[curr].append(meta)
+        curr_value = meta[meta_key]
+        curr_value = str(curr_value)
+        if curr_value not in values.keys():
+            values[curr_value] = [meta]
+        values[curr_value].append(meta)
         
     max_key = max_len_key(values)
     return values[max_key]
@@ -221,8 +230,3 @@ def calculate_max_overlap(meta_files: List[Dict[str, Any]], max_key: str) -> Lis
 def max_len_key(elements: Dict[str, List[Dict[str, Any]]]) -> str:
     """Return the key that has the longest list as a value."""
     return max(elements, key=lambda x: len(elements[x]))
-
-
-def group_by_key(meta_files: List[Dict[str, Any]], key: str) -> Any:
-    """Group the metadata files by a specific key and return the results as a dictionary."""
-    return meta_files

--- a/src/tsdf/io.py
+++ b/src/tsdf/io.py
@@ -221,7 +221,7 @@ def write_to_file(dict: Dict[str, Any], dir_path: str, file_name: str) -> None:
     """Write a dictionary to a json file."""
     path = os.path.join(dir_path, file_name)
     with open(path, "w") as convert_file:
-        convert_file.write(pprint.pformat(dict))
+        convert_file.write(json.dumps(dict, indent=4))
 
 
 def calculate_max_overlap(meta_files: List[Dict[str, Any]], meta_key: str) -> List[Dict[str, Any]]:

--- a/src/tsdf/io.py
+++ b/src/tsdf/io.py
@@ -13,7 +13,7 @@ from tsdf.numpy_utils import (
     endianness_tsdf_to_numpy,
     rows_numpy_to_tsdf,
 )
-from tsdf.tsdf_metadata import TSDFMetadata
+from tsdf.tsdf_metadata import TSDFMetadata, TSDFMetadataFieldValueError
 
 
 def load_metadata_file(file) -> Dict[str, TSDFMetadata]:
@@ -126,7 +126,7 @@ def write_binary_file(
 def write_metadata(metadatas: List[TSDFMetadata], file_name: str) -> None:
     """Combine and save the TSDF metadata objects as a json file."""
     if len(metadatas) == 0:
-        raise Exception(
+        raise TSDFMetadataFieldValueError(
             "Metadata cannot be saved, as the list of TSDFMetadata objects is empty."
         )
 
@@ -141,8 +141,8 @@ def write_metadata(metadatas: List[TSDFMetadata], file_name: str) -> None:
     plain_meta = [meta.get_plain_tsdf_dict_copy() for meta in metadatas]
     overlap = extract_dict_overlap(plain_meta)
     if not overlap:
-        raise Exception(
-            "Metadata files mist have at least one common field. Otherwise, they should be stored separtely."
+        raise TSDFMetadataFieldValueError(
+            "Metadata files mist have at least one common field. Otherwise, they should be stored separately."
         )
 
     overlap["sensors"] = optimise_dict_structure_rec(plain_meta)

--- a/src/tsdf/io.py
+++ b/src/tsdf/io.py
@@ -1,4 +1,5 @@
 import json
+import pprint
 import os
 import sys
 from typing import Any, Dict, List
@@ -145,7 +146,8 @@ def write_metadata(metadatas: List[TSDFMetadata], file_name: str) -> None:
             "Metadata files mist have at least one common field. Otherwise, they should be stored separately."
         )
 
-    overlap["sensors"] = calculate_ovelaps_rec(plain_meta)
+    if(len(plain_meta) > 0):
+        overlap["sensors"] = calculate_ovelaps_rec(plain_meta)
     write_to_file(overlap, metadatas[0].file_dir_path, file_name)
 
 
@@ -158,7 +160,7 @@ def extract_common_fields(metadatas: List[Dict[str, Any]]) -> Dict[str, Any]:
     if len(metadatas) == 0:
         return meta_overlap
     if len(metadatas) == 1:
-        return metadatas[0]
+        return metadatas.pop(0)
     init_metadata = metadatas[0]
     for key, value in init_metadata.items():
         key_in_all = True
@@ -177,6 +179,12 @@ def calculate_ovelaps_rec(
     metadatas: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """TODO: A recursive call that should optimise the structure of the TSDF metadata, by grouping common values."""
+
+    if len(metadatas) == 0:
+        return []
+    if len(metadatas) == 1:
+        return metadatas
+
     overlap_per_key: Dict[str, List[Dict[str, Any]]] = {} # Overlap for each key
     final_metadata: List[Dict[str, Any]] = [] # The metadata that is left to be processed
 
@@ -190,7 +198,8 @@ def calculate_ovelaps_rec(
 
     # Handle the first group
     first_overlap = extract_common_fields(first_group)
-    first_overlap["sensors"] = calculate_ovelaps_rec(first_group)
+    if(len(first_group) > 0):
+        first_overlap["sensors"] = calculate_ovelaps_rec(first_group)
     final_metadata.append(first_overlap)
 
     # Handle the rest of the elements
@@ -212,7 +221,7 @@ def write_to_file(dict: Dict[str, Any], dir_path: str, file_name: str) -> None:
     """Write a dictionary to a json file."""
     path = os.path.join(dir_path, file_name)
     with open(path, "w") as convert_file:
-        convert_file.write(json.dumps(dict))
+        convert_file.write(pprint.pformat(dict))
 
 
 def calculate_max_overlap(meta_files: List[Dict[str, Any]], meta_key: str) -> List[Dict[str, Any]]:

--- a/src/tsdf/io.py
+++ b/src/tsdf/io.py
@@ -154,6 +154,11 @@ def extract_common_fields(metadatas: List[Dict[str, Any]]) -> Dict[str, Any]:
     A new dict is created and the fields are removed from the original dictionaries."""
     meta_overlap: Dict[str, Any] = {}
 
+    # Return empty dict if metadatas is empty
+    if len(metadatas) == 0:
+        return meta_overlap
+    if len(metadatas) == 1:
+        return metadatas[0]
     init_metadata = metadatas[0]
     for key, value in init_metadata.items():
         key_in_all = True
@@ -165,7 +170,6 @@ def extract_common_fields(metadatas: List[Dict[str, Any]]) -> Dict[str, Any]:
     for key, _ in meta_overlap.items():
         for meta_dict in metadatas:
             meta_dict.pop(key)
-
     return meta_overlap
 
 
@@ -215,11 +219,12 @@ def calculate_max_overlap(meta_files: List[Dict[str, Any]], meta_key: str) -> Li
     """Calculate the maximum overlap between the metadata files, for a specific key. It returns the biggest group of dictionaries that contain the same value for the given meta_key."""
     values : Dict[str, List[Dict[str, Any]]] = {} # Key: a value for the given meta_key, Value: list of metadata files that have that value
     for meta in meta_files:
-        curr_value = meta[meta_key]
-        curr_value = str(curr_value)
-        if curr_value not in values.keys():
-            values[curr_value] = [meta]
-        values[curr_value].append(meta)
+        if meta_key in meta.keys():
+            curr_value = str(meta[meta_key])
+            if curr_value not in values.keys():
+                values[curr_value] = [meta]
+            else:
+                values[curr_value].append(meta)
         
     max_key = max_len_key(values)
     return values[max_key]

--- a/src/tsdf/tsdf_metadata.py
+++ b/src/tsdf/tsdf_metadata.py
@@ -14,6 +14,7 @@ class TSDFMetadataFieldValueError(Exception):
     pass
 
 
+
 class TSDFMetadata:
     """Structure that provides metadata needed for reading a data stream."""
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -124,12 +124,12 @@ class TestMetadataFileWriting(unittest.TestCase):
         rs = np.random.RandomState(seed=42)
         data_1 = rs.rand(17, 1).astype(np.float32)
         data_2 = rs.rand(15, 2).astype(np.int16)
+        data_3 = rs.rand(10, 3).astype(np.int16)
 
-        meta_file = "dummy_10_3_int16.json"
-        bin_file = "dummy_10_3_int16.bin"
-        path = os.path.join(TESTDATA_DIR, meta_file)
+        use_case_name = "dummy_10_3_int16"
+        path = TESTDATA_FILES[use_case_name]
         loaded_meta: tsdf_metadata.TSDFMetadata = io.load_metadata_from_path(path)[
-            bin_file
+            use_case_name + ".bin"
         ]
 
         new_meta_1 = io.write_binary_file(
@@ -145,17 +145,25 @@ class TestMetadataFileWriting(unittest.TestCase):
             loaded_meta.get_plain_tsdf_dict_copy(),
         )
 
+        new_meta_3 = io.write_binary_file(
+            TESTDATA_DIR,
+            test_name + "_3.bin",
+            data_3,
+            loaded_meta.get_plain_tsdf_dict_copy(),
+        )
+
         # Combine two TSDF files
-        io.write_metadata([new_meta_1, new_meta_2], test_name + ".json")
+        io.write_metadata([new_meta_1, new_meta_2, new_meta_3], test_name + ".json")
 
         # Read the written metadata
 
         meta = io.load_metadata_from_path(
             os.path.join(TESTDATA_DIR, test_name + ".json")
         )
-        self.assertEqual(len(meta), 2)
+        self.assertEqual(len(meta), 3)
         self.assertEqual(meta[test_name + "_1.bin"].rows, 17)
         self.assertEqual(meta[test_name + "_2.bin"].rows, 15)
+        self.assertEqual(meta[test_name + "_3.bin"].rows, 10)
 
     def test_bin_processing_and_writing_metadata(self):
         """Test binary file reading, processing, and writing of the new binary and metadata files."""


### PR DESCRIPTION
The previous algorithm was naive and would combine only the fields common for all the metadata files. This one recursively combines the remaining parts of the metadata files. 

The algorithm is as follows:

1. Combine all common fields
2. Call the recursive function on the rest

The recursive function is as follows:

1. Base case: Only one metadata file
2. Find the key:value pair that is shared among the most number of metadata files
2.1 Among those metadata files combine all common fields
2.2 Call the recursive function on the rest
3. Call recursive function on the metadata files not used in step 2
