### PR TITLE
TSDF metadata fields - documentation update

### DIFF
--- a/docs/tsdf_channels_table.md
+++ b/docs/tsdf_channels_table.md
@@ -1,0 +1,108 @@
+# Custom field values (TSDF schema `Digital biomarkers for PD` extension)
+
+Within the `Digital biomarkers for PD` extension, some of the field types are further specialised to provide a better description of the data. These are described in the following sections.
+
+## Field: `channels`
+**Type:** `channel_type[]`         
+**Description:** Describes the content of the data written. `channel_type` is specific to the `Digital biomarkers for PD` extension.
+
+---
+
+**General types**
+|   `channel_type` name          | Recommended `unit`       | Description                                                                           |
+|----------------------------|-----------------------|---------------------------------------------------------------------------------------|
+| `iso8601_time`              | `time`                | Time in ISO8601 format, characterizing each data window by its starting time.          |
+
+---
+
+<details>
+<summary><b>PPG-related types</b></summary>
+
+|   `channel_type` name          | Recommended `unit`       | Description                                                                           |
+|----------------------------|-----------------------|---------------------------------------------------------------------------------------|
+| `ppg_quality_post_prob`     | `probability`         | `[TODO]` Posterior probability that the corresponding PPG signal is of high quality (0 to 1).   |
+</details>
+
+---
+
+<details>
+<summary><b>Tremor-related types</b></summary>
+
+| `channel_type` name       | Recommended `unit` | Description                                                                         |
+|--------------------------|--------------------|-------------------------------------------------------------------------------------|
+| `gyro_tremor_prob`       | `probability`      | Probability values (0 to 1) indicating the likelihood of tremor activity for each sample. |
+| `gyro_tremor_hat`        | `boolean_num`         | Estimated values representing the presence or absence of tremor activity for each sample. |
+| `gyro_arm_actv_prob`     | `probability`      | Probability values (0 to 1) indicating the likelihood of arm activity for each sample.    |
+| `gyro_arm_actv_hat`      | `boolean_num`         | Estimated values representing the presence or absence of arm activity for each sample.    |
+| `GyMeanDx`               | `unitless`         | Mean gyro derivative in the x axis. |
+| `GyMeanDy`               | `unitless`         | Mean gyro derivative in the y axis. |
+| `GyMeanDz`               | `unitless`         | Mean gyro derivative in the z axis. |
+| `GyLTreDomPowerX`        | `unitless`         | Gyro Low tremor (range [3.5-8 Hz]) dominant power in the x axis. |
+| `GyLTreDomPowerY`        | `unitless`         | Gyro Low tremor (range [3.5-8 Hz]) dominant power in the y axis. |
+| `GyLTreDomPowerZ`        | `unitless`         | Gyro Low tremor (range [3.5-8 Hz]) dominant power in the z axis. |
+| `GyGaitBandPower`        | `unitless`         | Gyro gait bandpower (range [0.4 – 2] Hz) – PSD: sum of the axes. |
+| `GyGaitBandpowerRatio`   | `unitless`         | Gyro gait bandpower sum / total bandpower sum up to 15 Hz – PSD: sum of the axes. |
+| `GyGaitFreqPeak`         | `unitless`         | Frequency peak of the in the gyro gait range – PSD: sum of the axes. |
+| `GyGaitFixedDomPower`    | `unitless`         | `[TODO]` Gyro dominant power in a fixed range (specific frequency range not provided). |
+| `GyGaitFixedDomPowerRatio` | `unitless`       | `[TODO]` Ratio of dominant power in the gyro gait range to total power. |
+| `GyGaitDomPower`         | `unitless`         | `[TODO]` Dominant power in the gyro gait range. |
+| `GyGaitDomPowerRatio`    | `unitless`         | `[TODO]` Ratio of dominant power in the gyro gait range to total power. |
+| `GyGaitPeakFreqWidth`    | `unitless`         | `[TODO]` Width of the frequency peak in the gyro gait range. |
+| `GyLTreBandPower`        | `unitless`         | `[TODO]` Low tremor bandpower (specific frequency range not provided). |
+| `GyLTreBandpower`        | `unitless`         | `[TODO]` Low tremor bandpower (specific frequency range not provided). |
+| `GyLTreFreqPeak`         | `unitless`         | `[TODO]` Frequency peak in the low tremor range. |
+| `GyLTreFixedDomP`        | `unitless`         | `[TODO]` Low tremor dominant power in a fixed range (specific frequency range not provided). |
+| `GyLTreFixedDomP`        | `unitless`         | `[TODO]` Low tremor dominant power in a fixed range (specific frequency range not provided). |
+| `GyLTreDomPower`         | `unitless`         | `[TODO]` Low tremor dominant power (specific frequency range not provided). |
+| `GyLTreDomPowerR`        | `unitless`         | `[TODO]` Ratio of low tremor dominant power to total power. |
+| `GyLTrePeakFreqW`        | `unitless`         | `[TODO]` Width of the frequency peak in the low tremor range. |
+| `GyHTreBandPower`        | `unitless`         | `[TODO]` High tremor bandpower (specific frequency range not provided). |
+| `GyHTreBandpower`        | `unitless`         | `[TODO]` High tremor bandpower (specific frequency range not provided). |
+| `GyHTreFreqPeak`         | `unitless`         | `[TODO]` Frequency peak in the high tremor range. |
+| `GyHTreFixedDomP`        | `unitless`         | `[TODO]` High tremor dominant power in a fixed range (specific frequency range not provided). |
+| `GyHTreFixedDomP`        | `unitless`         | `[TODO]` High tremor dominant power in a fixed range (specific frequency range not provided). |
+| `GyHTreDomPower`         | `unitless`         | `[TODO]` High tremor dominant power (specific frequency range not provided). |
+| `GyHTreDomPowerR`        | `unitless`         | `[TODO]` Ratio of high tremor dominant power to total power. |
+| `GyHTrePeakFreqW`        | `unitless`         | `[TODO]` Width of the frequency peak in the high tremor range. |
+| `GyMFCC1`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 1. |
+| `GyMFCC2`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 2. |
+| `GyMFCC3`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 3. |
+| `GyMFCC4`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 4. |
+| `GyMFCC5`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 5. |
+| `GyMFCC6`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 6. |
+| `GyMFCC7`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 7. |
+| `GyMFCC8`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 8. |
+| `GyMFCC9`                | `unitless`         | `[TODO]` Mel-frequency cepstral coefficient 9. |
+
+
+</details>
+
+---
+
+<details>
+<summary><b>Gait-related types</b></summary>
+
+| `channel_type` name       | Recommended `unit` | Description                                                                         |
+|--------------------------|--------------------|-------------------------------------------------------------------------------------|
+| `accel_gait_feature_1`       | `unitless`            | `[TODO]` Gait-related feature 1 estimated from accelerometer data based on the windowed data `[TODO]`.     |
+| `accel_gait_feature_2`       | `unitless`            | `[TODO]` Gait-related feature 2 estimated from accelerometer data based on the windowed data `[TODO]`.     |
+| `accel_gait_prob`           | `probability`         | `[TODO]` Probability values (0 to 1) indicating the likelihood of gait activity for each sample.  |
+| `accel_arm_swing_feature1`  | `unitless`            | `[TODO]` Arm swing-related feature 1 estimated from accelerometer data based on the windowed data`[TODO]`. |
+| `accel_arm_swing_feature2`  | `unitless`            | `[TODO]` Arm swing-related feature 2 estimated from accelerometer data based on the windowed data`[TODO]`. |
+| `accel_arm_swing_prob`      | `probability`         | `[TODO]` Probability values (0 to 1) indicating the likelihood of arm swing activity for each sample. |
+</details>
+
+---
+---
+
+## Field: `units`
+**Type:** `unit_type[]`         
+**Description:** Describes the format of the data written. `unit_type` is specific to the `Digital biomarkers for PD` extension.
+
+
+|   `unit_type` name          | Description                                                                           |
+|----------------------------|---------------------------------------------------------------------------------------|
+| `time`              | Time in ISO8601 format, characterizing each data window by its starting time.                |
+| `probability`       | Probability values (0 to 1) indicating the likelihood of tremor activity for each sample.    |
+| `boolean_num`       | `[TODO]` Integer values (0 or 1) representing the true (1) or false (0) presence of an activity.      |
+| `unitless`          | Numerical values without units.                                                              |

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -1,4 +1,4 @@
-# TSDF fields
+# TSDF schema - metadata fields
 
 TSDF metadata is represented as a dictionary. In this section, we will comprehensively list the mandatory and optional fields within the TSDF format.
 
@@ -26,7 +26,7 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 
 
-## TSDF domain-specific fields
+## TSDF schema `Digital biomarkers for PD` extension
 
 ### Mandatory fields
 
@@ -34,12 +34,12 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 |----------------------------|--------------|-----------------------------------------------------------------------------------|
 | `bin_data_type`             | `bin_data_type`      | Size of the window (in seconds) used in the analysis.                             |
 | `window_size_sec`          | `float`               | Size of the window (in seconds) used in the analysis.                             |
-| `window_overlapped`        | `bool`                | Indicates whether there is overlap between consecutive windows in the analysis.     |
+| `window_overlapped`        | `bool`                | Indicates whether there is overlap between consecutive windows in the analysis.   |
 | `step_size_sec`            | `float`               | Duration in seconds for each segment in the written data.                         |
 | `freq_sampling`            | `int`                 | Sampling frequency of the data.                                                   |
 
 where `bin_data_type` can be one of the following:
-- `iso8601_time`:           Time in iso8601 format, where each data window is characterised by the starting time ().
+- `iso8601_time`:           Time in iso8601 format, where each data window is characterised by the starting time (DateTime,TimeUnixClass).
 - `gyro-tremor-features`:   Tremor-related features estimated (from gyro data) based on the windowed data (FeaturesGyro).
 - `gyro-tremor-prob`:       Probability values indicating the likelihood (on the scale 0 to 1) of tremor activity for each sample (TremorProb)
 - `gyro-tremor-hat`:        Estimated values representing the presence or absence of tremor activity for each sample (TremorHat).
@@ -88,23 +88,6 @@ These fields are optional, and provide standardised vocabulary for describing th
 | `z_score_normalised`         | `bool`       | Indicates whether z-score normalization was applied to the data. |
 | `start_datetime_unix_ms`     | `string`     | UNIX timestamp for the start of the recording (milliseconds). Equivalent to `start_iso8601` in UNIX format.   |
 | `end_datetime_unix_ms`       | `string`     | UNIX timestamp for the end of the recording (milliseconds). Equivalent to `end_iso8601` in UNIX format.   | 
-| `scale_factors`              | `float[]`    | Scale factors applied to each data channel to adjust their values.          | 
-| `freq_sampling_original`     | `int`        | Represents the original sampling frequency at which the data was recorded. |
-| `freq_sampling_adjusted`     | `int`        | The adjusted sampling frequency optimized for data processing or analysis. |
-| `gravity_removal`            | `bool`       | When true, the gravity component is removed to isolate user motion. |
-| `normalize_acceleration`     | `bool`       | If true, accelerometer data is normalized using z-score normalization. |
-| `motion_intensity_thresholds` | `int[]`     | List of percentage thresholds for categorizing motion intensity. |
-| `accelerometer_burst_thresholds` | `float[]` | Threshold values for detecting 'burst' or sudden motion in the accelerometer. |
-| `gyroscope_burst_thresholds` | `float[]`    | Threshold values for detecting 'burst' or sudden motion in the gyroscope. |
-| `active_burst_threshold_percentile` | `int` | Chosen percentile index for active burst threshold from the list of percentile values. |
-| `average_acceleration_across_weeks` | `float` | Average accelerometer reading across multiple weeks. |
-| `acceleration_stddev_across_weeks` | `float` | Standard deviation of accelerometer readings across weeks. |
-| `average_gyroscope_across_weeks` | `float` | Average gyroscope reading across weeks. |
-| `gyroscope_stddev_across_weeks` | `float` | Standard deviation of gyroscope readings across weeks. |
-| `num_ECDE_coeff`             | `int`        | Number of ECDE coefficients considered in the analysis. |
-| `num_filters`                | `int`        | Number of filters applied to refine or isolate specific frequency bands. |
-| `num_ME1_coeff`              | `int`        | Number of ME1 coefficients considered during data processing. |
-| `max_frequency_filter`       | `int`        | Highest frequency limit for any applied filter. |
 
 
 

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -15,7 +15,7 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 | `start_iso8601`  | `str`        | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) time stamp for the start of the recording, with ms precision.     |
 | `end_iso8601`    | `str`        | Same as `start_iso8601`, but for the end of the recording.                     |
 | `file_name`      | `str`        | The name of the file in consideration, e.g., "eeee.bin".                     |
-| `channels`       | `str[]`      | Labels for each data channel (_e.g.:_ `[time]` for time channel or `[X, Y, Z]` for 3D accelerometry).                      |
+| `channels`       | `str[]`      | Labels for each data channel (_e.g.:_ `[time]` for time data or `[X, Y, Z]` for 3D accelerometry).                      |
 | `time_encode`    | `str`        | Encoding type for time, e.g., "difference".                                  |
 | `units`          | `str[]`      | Units for each channel in the data, e.g., "ms" for milliseconds.             |
 | `data_type`      | `str`        | Number format of the measured data (_e.g.:_ `float`).                                             |

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -32,13 +32,13 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 | Field                      | Type         | Description                                                                       |
 |----------------------------|--------------|-----------------------------------------------------------------------------------|
-| `bin_data_type`             | `bin_data_type`      | Size of the window (in seconds) used in the analysis.                             |
+| `pd_bin_content`         | `bin_content_type`         | Description of the content of the data written in the binary file. The type is specific to the `Digital biomarkers for PD` extension. |
 | `window_size_sec`          | `float`               | Size of the window (in seconds) used in the analysis.                             |
 | `window_overlapped`        | `bool`                | Indicates whether there is overlap between consecutive windows in the analysis.   |
 | `step_size_sec`            | `float`               | Duration in seconds for each segment in the written data.                         |
 | `freq_sampling`            | `int`                 | Sampling frequency of the data.                                                   |
 
-where `bin_data_type` can be one of the following:
+where `bin_content_type` can be one of the following:
 - `iso8601_time`:           Time in iso8601 format, where each data window is characterised by the starting time (DateTime,TimeUnixClass).
 - `gyro-tremor-features`:   Tremor-related features estimated (from gyro data) based on the windowed data (FeaturesGyro).
 - `gyro-tremor-prob`:       Probability values indicating the likelihood (on the scale 0 to 1) of tremor activity for each sample (TremorProb)

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -26,9 +26,9 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 
 
-## TSDF schema `Digital biomarkers for PD` extension
+# TSDF schema `Digital biomarkers for PD` extension
 
-### Mandatory fields
+## Mandatory fields
 
 | Field                      | Type         | Description                                                                       |
 |----------------------------|--------------|-----------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ where `bin_content_type` can be one of the following:
 - `accel_arm_swing_prob`:   Probability values indicating the likelihood (on the scale 0 to 1) of arm swing activity for each sample ().
 
 
-### **Tremor** pipeline specific fields
+## **Tremor** pipeline specific fields
 
 | Field                      | Type         | Description                                                                  |
 |----------------------------|--------------|------------------------------------------------------------------------------|
@@ -66,7 +66,7 @@ where `bin_content_type` can be one of the following:
 | `sum_squared_features_gyro_scale` | `str[]`            | Scaling factors for the sum of squared gyro features.                                 |
 | `n_features_gyro_scale`     | `int`                    | Scaling factor for the number of gyro features.                                        |
 
-### **PPG** pipeline specific fields
+## **PPG** pipeline specific fields
 
 | Field                      | Type                 | Description                                                                  |
 |----------------------------|----------------------|------------------------------------------------------------------------------|
@@ -92,7 +92,7 @@ These fields are optional, and provide standardised vocabulary for describing th
 
 
 
-## Legacy fields
+# Legacy fields
 
 The following table lists the legacy fields from the time when the format was called TSDB, along with their updated counterparts:
 

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -30,12 +30,27 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 ### Mandatory fields
 
-| Field                      | Type         | Description                                                                  |
-|----------------------------|--------------|------------------------------------------------------------------------------|
-| `window_size_sec`          | `float`      | Size of the window (in seconds) used in the analysis.                               |
-| `window_overlapped`         | `bool`    | Indicates whether there is overlap between consecutive windows in the analysis.                         |
-| `step_size_sec`            | `float`      | Duration in seconds for each segment in the written data.                        |
-| `freq_sampling`            | `int`        | Sampling frequency of the data.                                              |
+| Field                      | Type         | Description                                                                       |
+|----------------------------|--------------|-----------------------------------------------------------------------------------|
+| `bin_data_type`             | `bin_data_type`      | Size of the window (in seconds) used in the analysis.                             |
+| `window_size_sec`          | `float`               | Size of the window (in seconds) used in the analysis.                             |
+| `window_overlapped`        | `bool`                | Indicates whether there is overlap between consecutive windows in the analysis.     |
+| `step_size_sec`            | `float`               | Duration in seconds for each segment in the written data.                         |
+| `freq_sampling`            | `int`                 | Sampling frequency of the data.                                                   |
+
+where `bin_data_type` can be one of the following:
+- `iso8601_time`:           Time in iso8601 format, where each data window is characterised by the starting time ().
+- `gyro-tremor-features`:   Tremor-related features estimated (from gyro data) based on the windowed data (FeaturesGyro).
+- `gyro-tremor-prob`:       Probability values indicating the likelihood (on the scale 0 to 1) of tremor activity for each sample (TremorProb)
+- `gyro-tremor-hat`:        Estimated values representing the presence or absence of tremor activity for each sample (TremorHat).
+- `gyro-arm-actv-prob`:     Probability values indicating the likelihood (on the scale 0 to 1) of arm activity for each sample (ArmActvProb).
+- `gyro-arm-actv-hat`:      Estimated values representing the presence or absence of arm activity for each sample (ArmActvHat).
+- `ppg-quality-post-prob`:  Posterior probability that the corresponding PPG signal is of high quality (PostProb).
+- `accel_gait_features`:    Gait-related features estimated (from accelerometer data) based on the windowed data ().
+- `accel_gait_prob`:        Probability values indicating the likelihood (on the scale 0 to 1) of gait activity for each sample ().
+- `accel_arm_swing_features`: Arm swing-related features estimated (from accelerometer data) based on the windowed data ().
+- `accel_arm_swing_prob`:   Probability values indicating the likelihood (on the scale 0 to 1) of arm swing activity for each sample ().
+
 
 ### **Tremor** pipeline specific fields
 
@@ -45,15 +60,18 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 | `mfcc_num_mel_coeff`       | `float`      | Number of coefficients used for estimating the mel-frequency cepstral coefficients. |
 | `mfcc_max_freq_filter`     | `float`      | Maximum frequency (in Hz) used for filtering in mel-frequency cepstral coefficients. |
 | `mfcc_window_size`         | `float`      | Size of the sub-window in seconds used to estimate the spectrogram used in the evaluation of the mel-frequency cepstral coefficients. |
-| `features_gyro`            | `float [sample_size x feature_size]` | Features estimated based on the windowed data.  |
+| `feature_names`             | `str[]`                  | List of names for the features.                                                      |
+| `excluded_hours`            | `int[]`                  | Scaling factors for excluded hours.                                                   |
+| `sum_features_gyro_scale`   | `str[]`                  | Scaling factors for the sum of gyro features.                                          |
+| `sum_squared_features_gyro_scale` | `str[]`            | Scaling factors for the sum of squared gyro features.                                 |
+| `n_features_gyro_scale`     | `int`                    | Scaling factor for the number of gyro features.                                        |
 
 ### **PPG** pipeline specific fields
 
 | Field                      | Type                 | Description                                                                  |
 |----------------------------|----------------------|------------------------------------------------------------------------------|
-| `post_prob`                | `float [sample_size x 1]`| Posterior probability that a signal is of high quality. |
 | `segment_number`           | `int`                | Order number of the analyzed data segment. |
-| `freq_sampling_original`   | `int`        | Sampling frequency (in Hz) of the original data (before adjustments for the analysis).                                              |
+| `freq_sampling_original`   | `int`                | Sampling frequency (in Hz) of the original data (before adjustments for the analysis).                                              |
 
 
 ## Additional TSDF field descriptions

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -1,6 +1,6 @@
 # TSDF schema - metadata fields
 
-TSDF metadata is represented as a dictionary. In this section, we will comprehensively list the mandatory and optional fields within the TSDF format.
+TSDF metadata is represented as a dictionary (or a JSON object). In this section, we will comprehensively list the mandatory and optional fields within the TSDF format.
 
 ## TSDF v0.1 mandatory fields
 
@@ -32,24 +32,13 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 | Field                      | Type         | Description                                                                       |
 |----------------------------|--------------|-----------------------------------------------------------------------------------|
-| `pd_bin_content`         | `bin_content_type`         | Description of the content of the data written in the binary file. The type is specific to the `Digital biomarkers for PD` extension. |
 | `window_size_sec`          | `float`               | Size of the window (in seconds) used in the analysis.                             |
-| `window_overlapped`        | `bool`                | Indicates whether there is overlap between consecutive windows in the analysis.   |
+| `window_overlapped`        | `float`                | Indicates whether there is overlap between consecutive windows in the analysis.   |
 | `step_size_sec`            | `float`               | Duration in seconds for each segment in the written data.                         |
-| `freq_sampling`            | `int`                 | Sampling frequency of the data.                                                   |
+| `freq_sampling`            | `int`                 | Sampling frequency (in Hz) of the input data.                                                   |
+| `channels`         | [channel_type](tsdf_channels_table.md)`[]`         | Description of the content of the data written. `channel_type` is specific to the `Digital biomarkers for PD` extension. |
+| `units`         | [unit_type](tsdf_channels_table.md)`[]`         | Description of the format of the data written. `unit_type` is specific to the `Digital biomarkers for PD` extension. |
 
-where `bin_content_type` can be one of the following:
-- `iso8601_time`:           Time in iso8601 format, where each data window is characterised by the starting time (DateTime,TimeUnixClass).
-- `gyro-tremor-features`:   Tremor-related features estimated (from gyro data) based on the windowed data (FeaturesGyro).
-- `gyro-tremor-prob`:       Probability values indicating the likelihood (on the scale 0 to 1) of tremor activity for each sample (TremorProb)
-- `gyro-tremor-hat`:        Estimated values representing the presence or absence of tremor activity for each sample (TremorHat).
-- `gyro-arm-actv-prob`:     Probability values indicating the likelihood (on the scale 0 to 1) of arm activity for each sample (ArmActvProb).
-- `gyro-arm-actv-hat`:      Estimated values representing the presence or absence of arm activity for each sample (ArmActvHat).
-- `ppg-quality-post-prob`:  Posterior probability that the corresponding PPG signal is of high quality (PostProb).
-- `accel_gait_features`:    Gait-related features estimated (from accelerometer data) based on the windowed data ().
-- `accel_gait_prob`:        Probability values indicating the likelihood (on the scale 0 to 1) of gait activity for each sample ().
-- `accel_arm_swing_features`: Arm swing-related features estimated (from accelerometer data) based on the windowed data ().
-- `accel_arm_swing_prob`:   Probability values indicating the likelihood (on the scale 0 to 1) of arm swing activity for each sample ().
 
 
 ## **Tremor** pipeline specific fields
@@ -61,10 +50,10 @@ where `bin_content_type` can be one of the following:
 | `mfcc_max_freq_filter`     | `float`      | Maximum frequency (in Hz) used for filtering in mel-frequency cepstral coefficients. |
 | `mfcc_window_size`         | `float`      | Size of the sub-window in seconds used to estimate the spectrogram used in the evaluation of the mel-frequency cepstral coefficients. |
 | `feature_names`             | `str[]`                  | List of names for the features.                                                      |
-| `excluded_hours`            | `int[]`                  | Scaling factors for excluded hours.                                                   |
-| `sum_features_gyro_scale`   | `str[]`                  | Scaling factors for the sum of gyro features.                                          |
-| `sum_squared_features_gyro_scale` | `str[]`            | Scaling factors for the sum of squared gyro features.                                 |
-| `n_features_gyro_scale`     | `int`                    | Scaling factor for the number of gyro features.                                        |
+| `excluded_hours`            | `int[]`                  | List of the excluded hours from the analysis (vector scaling?)???                                                   |
+| `sum_features_gyro_scale`   | `float[]`                  | Scaling factors for the sum of tremor-related features (from gyro)???                                          |
+| `sum_squared_features_gyro_scale` | `float[]`            | Scaling factors for the sum of squared tremor-related features (from gyro)???                                 |
+| `n_features_gyro_scale`     | `int`                    | Scaling factor for the number of gyro features???                                        |
 
 ## **PPG** pipeline specific fields
 

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -15,10 +15,10 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 | `start_iso8601`  | `str`        | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) time stamp for the start of the recording, with ms precision.     |
 | `end_iso8601`    | `str`        | Same as `start_iso8601`, but for the end of the recording.                     |
 | `file_name`      | `str`        | The name of the file in consideration, e.g., "eeee.bin".                     |
-| `channels`       | `str[]`      | Labels for each data channel (_e.g.:_ `["time", "X", "Y", "Z"]` for 3D accelerometry).                      |
+| `channels`       | `str[]`      | Labels for each data channel (_e.g.:_ `[time]` for time channel or `[X, Y, Z]` for 3D accelerometry).                      |
 | `time_encode`    | `str`        | Encoding type for time, e.g., "difference".                                  |
 | `units`          | `str[]`      | Units for each channel in the data, e.g., "ms" for milliseconds.             |
-| `data_type`      | `str`        | Number format of the measured data (_e.g.:_ `"float"`).                                             |
+| `data_type`      | `str`        | Number format of the measured data (_e.g.:_ `float`).                                             |
 | `bits`           | `int`        | Bit-length of the number format (e.g., 32-bit).                                         |
 | `columns`        | `int`        | Number of columns in the data matrix.                                        |
 | `rows`           | `int`        | Number of rows in the data matrix.                                          |

--- a/docs/tsdf_fields_table.md
+++ b/docs/tsdf_fields_table.md
@@ -2,7 +2,7 @@
 
 TSDF metadata is represented as a dictionary. In this section, we will comprehensively list the mandatory and optional fields within the TSDF format.
 
-## TSDF mandatory fields
+## TSDF v0.1 mandatory fields
 
 | Field            | Type         | Description                                                                 |
 |------------------|--------------|-----------------------------------------------------------------------------|
@@ -25,20 +25,55 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 
 
 
+
 ## TSDF domain-specific fields
+
+### Mandatory fields
+
+| Field                      | Type         | Description                                                                  |
+|----------------------------|--------------|------------------------------------------------------------------------------|
+| `window_size_sec`          | `float`      | Size of the window (in seconds) used in the analysis.                               |
+| `window_overlapped`         | `bool`    | Indicates whether there is overlap between consecutive windows in the analysis.                         |
+| `step_size_sec`            | `float`      | Duration in seconds for each segment in the written data.                        |
+| `freq_sampling`            | `int`        | Sampling frequency of the data.                                              |
+
+### **Tremor** pipeline specific fields
+
+| Field                      | Type         | Description                                                                  |
+|----------------------------|--------------|------------------------------------------------------------------------------|
+| `mfcc_num_filters`         | `float`      | Number of filters used for estimating the mel-frequency cepstral coefficients. |
+| `mfcc_num_mel_coeff`       | `float`      | Number of coefficients used for estimating the mel-frequency cepstral coefficients. |
+| `mfcc_max_freq_filter`     | `float`      | Maximum frequency (in Hz) used for filtering in mel-frequency cepstral coefficients. |
+| `mfcc_window_size`         | `float`      | Size of the sub-window in seconds used to estimate the spectrogram used in the evaluation of the mel-frequency cepstral coefficients. |
+| `features_gyro`            | `float [sample_size x feature_size]` | Features estimated based on the windowed data.  |
+
+### **PPG** pipeline specific fields
+
+| Field                      | Type                 | Description                                                                  |
+|----------------------------|----------------------|------------------------------------------------------------------------------|
+| `post_prob`                | `float [sample_size x 1]`| Posterior probability that a signal is of high quality. |
+| `segment_number`           | `int`                | Order number of the analyzed data segment. |
+| `freq_sampling_original`   | `int`        | Sampling frequency (in Hz) of the original data (before adjustments for the analysis).                                              |
+
+
+## Additional TSDF field descriptions
+
+These fields are optional, and provide standardised vocabulary for describing the data.
 
 
 | Field                        | Type         | Description                                          |
 |------------------------------|--------------|------------------------------------------------------|
+| `week_number`                | `int`        | Denotes the specific week for tracking or comparing weekly data. |
+| `interpolated`               | `bool`       | Indicates whether interpolation was performed on the data. |
+| `high_pass_filter_applied`   | `bool`       | Indicates whether a high-pass filter was applied to remove low-frequency noise. |
+| `high_pass_filter_cutoff`    | `float`      | Cutoff frequency (in Hz) for the high-pass filter, in case it was applied. |
+| `z_score_normalised`         | `bool`       | Indicates whether z-score normalization was applied to the data. |
 | `start_datetime_unix_ms`     | `string`     | UNIX timestamp for the start of the recording (milliseconds). Equivalent to `start_iso8601` in UNIX format.   |
 | `end_datetime_unix_ms`       | `string`     | UNIX timestamp for the end of the recording (milliseconds). Equivalent to `end_iso8601` in UNIX format.   | 
 | `scale_factors`              | `float[]`    | Scale factors applied to each data channel to adjust their values.          | 
-| `week_number`                | `int`        | Denotes the specific week for tracking or comparing weekly data. |
 | `freq_sampling_original`     | `int`        | Represents the original sampling frequency at which the data was recorded. |
 | `freq_sampling_adjusted`     | `int`        | The adjusted sampling frequency optimized for data processing or analysis. |
-| `interpolate`                | `bool`       | If set to true, missing or irregular data points will be estimated and filled. |
 | `gravity_removal`            | `bool`       | When true, the gravity component is removed to isolate user motion. |
-| `apply_high_pass_filter`     | `bool`       | Indicates if a high-pass filter should be applied to remove low-frequency noise. |
 | `normalize_acceleration`     | `bool`       | If true, accelerometer data is normalized using z-score normalization. |
 | `motion_intensity_thresholds` | `int[]`     | List of percentage thresholds for categorizing motion intensity. |
 | `accelerometer_burst_thresholds` | `float[]` | Threshold values for detecting 'burst' or sudden motion in the accelerometer. |
@@ -48,7 +83,6 @@ TSDF metadata is represented as a dictionary. In this section, we will comprehen
 | `acceleration_stddev_across_weeks` | `float` | Standard deviation of accelerometer readings across weeks. |
 | `average_gyroscope_across_weeks` | `float` | Average gyroscope reading across weeks. |
 | `gyroscope_stddev_across_weeks` | `float` | Standard deviation of gyroscope readings across weeks. |
-| `window_size_sec`            | `int`        | Duration in seconds for each data window used in segmented analysis. |
 | `num_ECDE_coeff`             | `int`        | Number of ECDE coefficients considered in the analysis. |
 | `num_filters`                | `int`        | Number of filters applied to refine or isolate specific frequency bands. |
 | `num_ME1_coeff`              | `int`        | Number of ME1 coefficients considered during data processing. |


### PR DESCRIPTION
Defined a TSDF schema extension for the PD project:
- Standardised mandatory fields within the extension
- Introduced vocabularies for pipeline-specific fields
- Defined **channel** and **unit types**, which describe the binary data

Closes #30 

TODO:

- [ ] Discuss the fields with the pipeline experts
- [ ] Implement the support (within the tsdf lib) for the TSDF schema extension (created a separate issue)