### PR TITLE
Update Zenodo DOI to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ![Python package](https://github.com/biomarkersparkinson/tsdf/workflows/Python%20package/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/tsdf.svg)](https://pypi.python.org/pypi/tsdf/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7867900.svg)](https://doi.org/10.5281/zenodo.7867900)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7867899.svg)](https://doi.org/10.5281/zenodo.7867899)
 
 # tsdf
 


### PR DESCRIPTION
The DOI was pointing to a specific version (tsdf v0.2.0), I updated it to always point to the latest version.