### PR TITLE
Handle endianness for 1 byte INTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ dmypy.json
 
 tests/data/tmp_*
 docs/data/tmp_*
+local/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tsdf"
-version = "0.5.1"
+version = "0.5.2"
 description = "A Python library that provides methods for encoding and decoding TSDF (Time Series Data Format) data, which allows you to easily create, manipulate and serialize TSDF files in your Python code."
 authors = ["Peter Kok <p.kok@esciencecenter.nl>",
             "Pablo Rodríguez <p.rodriguez-sanchez@esciencecenter.nl>",

--- a/src/tsdf/numpy_utils.py
+++ b/src/tsdf/numpy_utils.py
@@ -61,6 +61,7 @@ _map_from_numpy_endianness = {
     "<": "little",
     ">": "big",
     "=": sys.byteorder,
+    "|": "not applicable",
 }
 """ Supported endianness values. """
 
@@ -79,6 +80,7 @@ def endianness_numpy_to_tsdf(data: np.ndarray) -> str:
 _map_to_numpy_endianness = {
     "little": "<",
     "big": ">",
+    "not applicable": "|",
 }
 """ Supported endianness values. """
 


### PR DESCRIPTION
Introduced a "not applicable" tag for the byte order of 1-byte integers to address the issue where specifying endianness was erroneously required. This update resolves the problem by clarifying that endianness is irrelevant for single-byte data types, allowing data processing of such cases. 
